### PR TITLE
update dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Toxblh/node-red-contrib-samsung-tv-control#readme",
   "dependencies": {
-    "samsung-tv-control": "1.7.2"
+    "samsung-tv-control": "1.9.0"
   },
   "devDependencies": {
     "jest": "^25.1.0",


### PR DESCRIPTION
now that the samsung-tv-control package has been updated, the nodered addon needs to use the newer version. I'm not sure.  Did I do it right?
see https://github.com/Toxblh/node-red-contrib-samsung-tv-control/issues/11