### PR TITLE
fixed uncaught exception on missing data (issue #93)

### DIFF
--- a/lib/samsung.js
+++ b/lib/samsung.js
@@ -160,12 +160,13 @@ function registerNodes(RED) {
       const device = RED.nodes.getNode(config.device)
 
       device.remote.getAppsFromTV(function (err, res) {
-        if (err || res.data.data === undefined) {
+        if (err || !res.data || res.data.data === undefined) {
           node.warn(err)
-        }
-        const apps = res.data.data
-        msg.payload = apps
-        node.send(msg)
+        } else {
+          const apps = res.data.data
+          msg.payload = apps
+          node.send(msg)
+        }        
       })
     })
   }


### PR DESCRIPTION
for unreachable TV the get apps call was running into uncaught exception due to accessing res.data which is null in this case